### PR TITLE
Run the callback with error for max retry limit

### DIFF
--- a/lib/simpledb.js
+++ b/lib/simpledb.js
@@ -189,7 +189,7 @@ exports.SimpleDB = function(opts,logger) {
           log('status',done,tryI,last,delay,err)
           opts.statuscb && opts.statuscb(done,tryI,last,delay,err)
 
-          if (last && err) {
+          if (last && err && err.message === 'URI malformed') {
             handler(err,null,null)
           }
         },


### PR DESCRIPTION
When doing a putItem or putItems I would get back an error from
amazon of 'URI malformed'.  This would retry 4 times and never run
my callback with the error.

I included an example to recreate this as a note on my commit.
