### PR TITLE
Escaping exclamation mark fix is needed from aws-lib 0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "John Roberts <jroberts@logitech.com>"
   ],
   "dependencies": {
-      "aws-lib": "0.0.5"
+      "aws-lib": "0.0.6"
   },
   "main": "lib/simpledb",
   "directories": {


### PR DESCRIPTION
https://github.com/livelycode/aws-lib/commit/304b0244e7e609f870de19dc643a91b581e288e5

Otherwise, queries with exclamation mark does not work.
