### PR TITLE
Check for null response

### DIFF
--- a/lib/simpledb.js
+++ b/lib/simpledb.js
@@ -145,7 +145,7 @@ exports.SimpleDB = function(opts,logger) {
     	return;
     }
 
-    if( res.Errors ) {
+    if( res && res.Errors ) {
       var error = arrayify(res.Errors.Error)[0]
       err = {Code:error.Code,Message:error.Message}
       meta.RequestId = res.RequestId
@@ -157,11 +157,13 @@ exports.SimpleDB = function(opts,logger) {
       }[err.Code])
     }
     else {
-      meta.RequestId = res.ResponseMetadata.RequestId
-      meta.BoxUsage  = res.ResponseMetadata.BoxUsage
+      if (res){
+        meta.RequestId = res.ResponseMetadata.RequestId
+        meta.BoxUsage  = res.ResponseMetadata.BoxUsage
+      }
     }
 
-    if( !err ) {
+    if( res && !err ) {
       // save new results
       if( res.SelectResult ) results = results.concat( res.SelectResult.Item )
       // check if we've achieved the max number of results


### PR DESCRIPTION
I have found that the `res` object is not always set. This PR guards against that.
