### PR TITLE
List all domains

### DIFF
--- a/lib/simpledb.js
+++ b/lib/simpledb.js
@@ -536,6 +536,8 @@ exports.SimpleDB = function(opts,logger) {
         out = []
         var items = arrayify(res.SelectResult.Item)
         items.forEach(function(item){
+          // exit now if an empty array
+          if(typeof item == "undefined") return
           var outitem = {$ItemName:item.Name}
           getattrs(outitem,arrayify(item.Attribute),asarrays)
           out.push(outitem)

--- a/lib/simpledb.js
+++ b/lib/simpledb.js
@@ -119,6 +119,7 @@ exports.SimpleDB = function(opts,logger) {
   // TODO - get aws-lib to support port
   awsopts.port    = null == opts.port    ? 80                  : opts.port
   awsopts.nolimit = null == opts.nolimit ? false               : opts.nolimit
+  awsopts.maxdomains= 100 // this is set by the AWS service:
   awsopts.maxlimit= 2500 // this is set by the AWS service: http://docs.aws.amazon.com/AmazonSimpleDB/latest/DeveloperGuide/SDBLimits.html
   // container to aggregate results of the select queries over maxlimit
   var results = []
@@ -134,7 +135,7 @@ exports.SimpleDB = function(opts,logger) {
     var err  = null
     var meta = {action:act,query:q,result:res,time:time,duration:time-start,trycount:tryI}
     var retry = false
-    
+
     if (!res){
        	if (last) {
      	  stop(true)
@@ -164,24 +165,36 @@ exports.SimpleDB = function(opts,logger) {
     }
 
     if( res && !err ) {
-      // save new results
-      if( res.SelectResult ) results = results.concat( res.SelectResult.Item )
-      // check if we've achieved the max number of results
+      // variables
       var maxcount = false;
+      var nextToken = null;
+      var count = 0;
+      // save new results
+      if( res.SelectResult ){
+        results = results.concat( res.SelectResult.Item );
+        nextToken = res.SelectResult.NextToken;
+        count = res.SelectResult.Item.length;
+      } else if( res.ListDomainsResult ){
+        results = results.concat( res.ListDomainsResult.DomainName );
+        nextToken = res.ListDomainsResult.NextToken;
+        count = res.ListDomainsResult.DomainName.length;
+      }
+      // check if we've achieved the max number of results
       try {
-        maxcount = ( res.SelectResult.Item.length == awsopts.maxlimit )
+        maxcount = ( res.SelectResult ) ? ( count == awsopts.maxlimit ) : ( count == awsopts.maxdomains )
       } catch( e ){
         // nothing to do...
       }
       // optionally make subsequent requests for queries over the max limit
-      if( awsopts.nolimit && maxcount && res.SelectResult.NextToken){
+      if( awsopts.nolimit && maxcount && nextToken){
         // get the next batch of results
-        q.NextToken = res.SelectResult.NextToken
+        q.NextToken = nextToken
         makereq(act,q,callback)
       } else {
         stop(true)
         // replacing with aggregated results only if nolimit is set
         if( awsopts.nolimit && res.SelectResult ) res.SelectResult.Item = results
+        if( awsopts.nolimit && res.ListDomainsResult ) res.ListDomainsResult.DomainName = results
         callback(err,res,meta)
       }
     }
@@ -582,4 +595,3 @@ exports.debuglogger = function(date,type) {
   }
   util.debug(strs.join(' '))
 }
-

--- a/lib/simpledb.js
+++ b/lib/simpledb.js
@@ -173,11 +173,11 @@ exports.SimpleDB = function(opts,logger) {
       if( res.SelectResult ){
         results = results.concat( res.SelectResult.Item );
         nextToken = res.SelectResult.NextToken;
-        count = res.SelectResult.Item.length;
+        count = ( res.SelectResult.Item ) ? res.SelectResult.Item.length : 0;
       } else if( res.ListDomainsResult ){
         results = results.concat( res.ListDomainsResult.DomainName );
         nextToken = res.ListDomainsResult.NextToken;
-        count = res.ListDomainsResult.DomainName.length;
+        count = ( res.ListDomainsResult.DomainName ) ? res.ListDomainsResult.DomainName.length : 0;
       }
       // check if we've achieved the max number of results
       try {

--- a/test/simpledb.test.js
+++ b/test/simpledb.test.js
@@ -494,6 +494,17 @@ module.exports = {
     })
   },
 
+  alldomains: function(){
+      var keys = require('./keys.mine.js')
+      sdb = new simpledb.SimpleDB({keyid:keys.id,secret:keys.secret,host:keys.host||awshost,nolimit:true},simpledb.debuglogger)
+      sdb.listDomains(function(err,res,meta){
+        debugres(null, err,res,meta)
+        assert.isNull(err)
+        console.log("Domain count:", res.length);
+        assert.isNotNull(res)
+      })
+  },
+
   nolimit: function() {
     var keys = require('./keys.mine.js')
     sdb = new simpledb.SimpleDB({keyid:keys.id,secret:keys.secret,host:keys.host||awshost,nolimit:true},simpledb.debuglogger)


### PR DESCRIPTION
Recently I went over 100 SimpleDB domains and I wanted to return all of them in one query. 

This patch addresses this by using the same conventions as with the "select" query, conditioning either a ```SelectResult``` or ```ListDomains``` dataset, based on the response...

A complementary test was added, although I didn't allow it to create 100 domains just for the sake of one test, instead it assumes your credentials could return over 100 domains...

If everyone's OK with this I can merge and tag a new version, which is about time to do anyway. 
