### PR TITLE
Update broken link to Open-Open policy explanation from github/Level

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 If you're using this library, feel free to contact me on twitter if you have any questions! :) [@rjrodger](http://twitter.com/rjrodger)
 
-NOTE: this project follows the [Open-Open](https://github.com/rvagg/node-levelup/blob/master/CONTRIBUTING.md) policy - if you submit a pull request or an issue, you get commit rights, so feel free to merge yourself after asking for feedback from the other contribs.
+NOTE: this project follows the [Open-Open](https://github.com/Level/community/blob/master/CONTRIBUTING.md) policy - if you submit a pull request or an issue, you get commit rights, so feel free to merge yourself after asking for feedback from the other contribs.
 
 IMPORTANT: YOUR CODE CONTRIBUTIONS (if any) ARE MADE UNDER THE MIT LICENSE. By submitting a pull request or issue you indicate agreement with this condition.
 


### PR DESCRIPTION
This project was my introduction to Open-Open, and I wanted to learn more! Unfortunately the current links appears to be to a file no longer in its repo, and Level has moved their contributing policies to their own bespoke repo.

I've confirmed the content new link substantially matches an [archived version](https://web.archive.org/web/20141205142533/https://github.com/rvagg/node-levelup/blob/master/CONTRIBUTING.md) of the replaced link.